### PR TITLE
Correct metalsmith-drafts version to v0.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "metalsmith-less": "^1.0.1",
     "metalsmith-markdown": "^0.2.1",
     "metalsmith-navigation": "^0.0.8",
-    "metalsmith-drafts": "0.1.1",
+    "metalsmith-drafts": "0.0.1",
     "metalsmith-templates": "^0.5.2",
     "yuidocjs": "^0.3.50"
   }


### PR DESCRIPTION
`npm install` fails after a fresh clone because the current version of `metalsmith-drafts` is `v0.0.1`, not `v0.1.1` as is specified in `package.json`.

See here: https://www.npmjs.org/package/metalsmith-drafts

Thanks!
